### PR TITLE
[FIX]P2022-1707 Maintenance of tests failing after changes

### DIFF
--- a/src/test/java/com/intive/template/pages/BoardHeaderPage.java
+++ b/src/test/java/com/intive/template/pages/BoardHeaderPage.java
@@ -6,14 +6,17 @@ import org.openqa.selenium.support.How;
 
 public class BoardHeaderPage extends BasePage {
 
-    @FindBy(how = How.XPATH, using = "/html/body/div/div/section/a")
+    @FindBy(how = How.XPATH, using = "/html/body/div/section/a")
     WebElement returnToMainBoardLink;
 
-    @FindBy(how = How.XPATH, using = "/html/body/div/div/section/div/h1")
+    @FindBy(how = How.XPATH, using = "/html/body/div/header/div")
     WebElement title;
 
-    @FindBy(how = How.XPATH, using = "/html/body/div/div/section/div/button")
+    @FindBy(how = How.XPATH, using = "/html/body/div/section/div/button")
     WebElement newColumnButton;
+
+    @FindBy(how = How.XPATH, using = "/html/body/div/div/a[1]/h4")
+    WebElement boardsFromDbBoard1Page;
     
     public boolean isReturnToMainBoardLinkVisible() {
         return returnToMainBoardLink.isDisplayed();
@@ -30,5 +33,7 @@ public class BoardHeaderPage extends BasePage {
     public void clickOnReturnToMainBoardLink() {
         returnToMainBoardLink.click();
     }
+
+    public void clickOnBoardsFromDbBoard1Button() {boardsFromDbBoard1Page.click();}
 }
 

--- a/src/test/java/com/intive/template/pages/ContextMenuPage.java
+++ b/src/test/java/com/intive/template/pages/ContextMenuPage.java
@@ -12,11 +12,11 @@ import java.time.Duration;
 
 public class ContextMenuPage extends BasePage {
 
-    @FindBy(how = How.XPATH, using = "/html/body/div/div/main/div[1]/div[2]/div/div/button")
+    @FindBy(how = How.XPATH, using = "//*[@id=\"__next\"]/div/div[1]/div[2]/div/div/button/span")
     WebElement triggerButton;
-    @FindBy(how = How.XPATH, using = "/html/body/div/div/main/div[1]/div[2]/div/div/nav")
+    @FindBy(how = How.XPATH, using = "//*[@id=\"01FV73TD3GSJ82YJE85XJRBT13\"]")
     WebElement openContextMenu;
-    @FindBy(how = How.XPATH, using = "/html/body/div/div/main/div[1]/div[2]/div/div/nav/ul")
+    @FindBy(how = How.XPATH, using = "/html/body/div/div/div[1]/div[2]/div/div/nav/ul")
     WebElement listOfItems;
     @FindBy(how = How.ID, using = "__next")
     WebElement item;

--- a/src/test/java/com/intive/template/pages/ModalComponentPage.java
+++ b/src/test/java/com/intive/template/pages/ModalComponentPage.java
@@ -6,7 +6,7 @@ import org.openqa.selenium.support.How;
 
 public class ModalComponentPage extends BasePage{
 
-    @FindBy(how = How.XPATH, using = "/html/body/div/div/main/button[1]")
+    @FindBy(how = How.XPATH, using = "/html/body/div/div/button[1]")
     WebElement openModalButton;
 
     @FindBy(how = How.XPATH, using = "/html/body/div[2]/div[2]/div[3]/button[1]")

--- a/src/test/java/com/intive/template/steps/BoardHeaderStepdefs.java
+++ b/src/test/java/com/intive/template/steps/BoardHeaderStepdefs.java
@@ -18,6 +18,11 @@ public class BoardHeaderStepdefs {
         assertThat("Board header component should contains New column button", boardHeaderPage.isNewColumnButtonVisible(), is(true));
     }
 
+    @When("Click on boards from db board 1 button")
+    public void clickOnBoardsFromDbBoard1Button() { boardHeaderPage.clickOnBoardsFromDbBoard1Button();
+
+    }
+
     @When("Click on Return to main board text")
     public void clickOnReturnToMainBoardText() {
         boardHeaderPage.clickOnReturnToMainBoardLink();

--- a/src/test/resources/features/boardHeaderComponent.feature
+++ b/src/test/resources/features/boardHeaderComponent.feature
@@ -3,6 +3,7 @@ Feature: Board header component feature
   @P2022-439
   Scenario: Board header component exists
     Given Open home page
+    When Click on boards from db board 1 button
     Then Board header component contains Return to main board text, title and new column button
 
   @P2022-439


### PR DESCRIPTION
Fixed 7 tests out of 9 that have failed due to the changed selectors on page. Still needs fixing: "Return to main board", "Board header component exists".